### PR TITLE
Fix: gup bodies not being removed, format error on load

### DIFF
--- a/Source/Modifiers/VoidFiendSkillModifiers.cs
+++ b/Source/Modifiers/VoidFiendSkillModifiers.cs
@@ -33,7 +33,7 @@ namespace SkillsPlusPlus.Source.Modifiers {
     //    }
 
     //}
-    [SkillLevelModifier(new[] { "FireHandBeam", "ChargeHandBeam", "FireCorruptBeam" }, typeof(FireHandBeam), typeof(ChargeHandBeam), typeof(FireCorruptHandBeam))]
+    [SkillLevelModifier(new[] { "FireHandBeam", "ChargeHandBeam", "FireCorruptBeam", "ChargeCorruptHandBeam" }, typeof(FireHandBeam), typeof(ChargeHandBeam), typeof(FireCorruptHandBeam), typeof(ChargeCorruptHandBeam))]
     class VoidFiendHandBeamSkillModifier : BaseSkillModifier {
         CharacterBody surv;
         private int debuffTimerAdd;
@@ -47,14 +47,13 @@ namespace SkillsPlusPlus.Source.Modifiers {
 
         public override void OnSkillEnter(BaseState skillState, int level) {
             base.OnSkillEnter(skillState, level);
+            Logger.Debug($"OnSkillEnter: {skillState.GetType().Name}");
             if(skillState is FireHandBeam beam) {
-                Logger.Debug("FireHandBeam");
                 Logger.Debug(debuffTimerAdd);
                 beam.damageCoefficient = MultScaling(beam.damageCoefficient, 0.10f, level);
                 debuffTimerAdd = level;
                 //beam.bulletCount = MultScaling(beam.bulletCount, 1, level);
             } else if (skillState is FireCorruptHandBeam corruptbeam) {
-                Logger.Debug("FireCorruptHandBeam");
                 corruptbeam.beamVfxPrefab.transform.localScale = new Vector3(corruptbeam.beamVfxPrefab.transform.localScale.x, corruptbeam.beamVfxPrefab.transform.localScale.y, MultScaling(1, 0.30f, level)); //vfx should extend a bit farther imo 
                 Logger.Debug("FireCorruptHandBeam" + corruptbeam.maxDistance);
                 corruptbeam.maxDistance = MultScaling(corruptbeam.maxDistance, 0.25f, level);
@@ -132,24 +131,6 @@ namespace SkillsPlusPlus.Source.Modifiers {
             if(victim.TryGetComponent(out CharacterBody charbody))
             {
                 charbody.AddTimedBuff(RoR2Content.Buffs.Slow50, 3 + debuffTimerAdd); // 3 is the one the damagetype adds 
-            }
-        }
-    }
-
-    [SkillLevelModifier("FireCorruptBeam", typeof(FireCorruptHandBeam), typeof(ChargeCorruptHandBeam))]
-    class VoidFiendCorruptHandBeamSkillModifier : BaseSkillModifier {
-
-        public override void OnSkillLeveledUp(int level, CharacterBody characterBody, SkillDef skillDef) {
-            base.OnSkillLeveledUp(level, characterBody, skillDef);
-        }
-
-        public override void OnSkillEnter(BaseState skillState, int level) {
-            base.OnSkillEnter(skillState, level);
-
-            if (skillState is FireCorruptHandBeam) {
-                Logger.Debug("FireCorruptHandBeam");
-            } else if (skillState is ChargeCorruptHandBeam) {
-                Logger.Debug("ChargeCorruptHandBeam");
             }
         }
     }

--- a/Source/SkillModifierManager.cs
+++ b/Source/SkillModifierManager.cs
@@ -59,7 +59,7 @@ namespace SkillsPlusPlus {
                             foreach (Type stateType in attribute.baseStateTypes) {
                                 if (typeToModifierMap.TryGetValue(stateType, out BaseSkillModifier existingModifier)) {
                                     Logger.Warn("Skill modifier conflict!!!");
-                                    Logger.Warn("Cannot add {0} since {1} already exists for the entity state {2}", existingModifier.GetType().FullName, stateType.FullName);
+                                    Logger.Warn("Cannot add {0} since {1} already exists for the entity state {2}", someSkillModifier.GetType().FullName, existingModifier.GetType().FullName, stateType.FullName);
                                     continue;
                                 }
                                 typeToModifierMap[stateType] = skillModifier;

--- a/Source/SkillUpgrade.cs
+++ b/Source/SkillUpgrade.cs
@@ -155,7 +155,9 @@ namespace SkillsPlusPlus {
             if (state.outer) {
                 if (state.outer.TryGetComponent(out CharacterBody characterBody)) {
                     if (characterBody.master && characterBody.master.gameObject.TryGetComponent(out MinionOwnership minion) && minion.ownerMaster) {
-                        if (bLogging) Logger.Debug(state.GetType().Name + ": Found MinionOwner in CharacterBody, returning " + minion.ownerMaster.GetBody().GetDisplayName());
+                        // GetBody() isn't guaranteed to not return a null reference
+                        var masterBody = minion.ownerMaster.GetBody();
+                        if (bLogging) Logger.Debug(state.GetType().Name + ": Found MinionOwner in CharacterBody, returning " + (masterBody?.GetDisplayName() ?? "[INVALID/REMOVED]"));
                         return minion.ownerMaster.GetBody();
                     }
 
@@ -166,13 +168,15 @@ namespace SkillsPlusPlus {
                     if (bLogging) Logger.Debug(state.GetType().Name + ": Found ProjectileController, returning " + projectileController.owner.GetComponent<CharacterBody>().GetDisplayName());
                     return projectileController.owner.GetComponent<CharacterBody>();
                 } else if (state.outer.TryGetComponent(out MinionOwnership minionOwnership) && minionOwnership.ownerMaster) {
-                    if (bLogging) Logger.Debug(state.GetType().Name + ": Found MinionOwnership, returning " + minionOwnership.ownerMaster.GetBody().GetDisplayName());
+                    var masterBody = minionOwnership.ownerMaster.GetBody();
+                    if (bLogging) Logger.Debug(state.GetType().Name + ": Found MinionOwnership, returning " + (masterBody?.GetDisplayName() ?? "[INVALID/REMOVED]"));
                     return minionOwnership.ownerMaster.GetBody();
                 } else if (state.outer.TryGetComponent(out GenericOwnership genericOwnership) && genericOwnership.ownerObject) {
                     if (bLogging) Logger.Debug(state.GetType().Name + ": Found GenericOwnership, returning " + genericOwnership.ownerObject.GetComponent<CharacterBody>().GetDisplayName());
                     return genericOwnership.ownerObject.GetComponent<CharacterBody>();
                 } else if (state.outer.TryGetComponent(out Deployable deployable) && deployable.ownerMaster) {
-                    if (bLogging) Logger.Debug(state.GetType().Name + ": Found Deployable, returning " + deployable.ownerMaster.GetBody().GetDisplayName());
+                    var masterBody = deployable.ownerMaster.GetBody(); // This isn't a gup, but knowing GetBody() can return null we should be checking it anyway
+                    if (bLogging) Logger.Debug(state.GetType().Name + ": Found Deployable, returning " + (masterBody?.GetDisplayName() ?? "[INVALID/REMOVED]"));
                     return deployable.ownerMaster.GetBody();
                 }
             }


### PR DESCRIPTION
Fixes the longstanding issue with Gup (slime) bodies sometimes not being removed due to an error in FindOwningCharacterBody (trace below).
```
System.NullReferenceException: Object reference not set to an instance of an object
  at SkillsPlusPlus.SkillUpgrade.FindOwningCharacterBody (EntityStates.EntityState state) [0x0009f] in <032e00c0b23242269f2e2d911557bb46>:IL_009F 
  at SkillsPlusPlus.SkillUpgrade.OnBaseStateEnter (On.EntityStates.BaseState+orig_OnEnter orig, EntityStates.BaseState self) [0x00016] in <032e00c0b23242269f2e2d911557bb46>:IL_0016 
  at (wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition.Hook<EntityStates.BaseState::OnEnter>?-1725250232(EntityStates.BaseState) (at IL_0019)
  at EntityStates.AffixEarthHealer.Chargeup.OnEnter () [0x00000] in <cba2c3feea8a4935a67769bf3df8c3d3>:IL_0000 
  ...
```
and fixes a FormatException on load due to a mismatched argument count when attempting to print a warning. Also fixes the source of that warning.
```
[Error  :  Skills++] System.FormatException: Index (zero based) must be greater than or equal to zero and less than the size of the argument list.
  at System.Text.StringBuilder.AppendFormatHelper (System.IFormatProvider provider, System.String format, System.ParamsArray args) [0x000f9] in <7e05db41a20b45108859fa03b97088d4>:IL_00F9 
  at System.String.FormatHelper (System.IFormatProvider provider, System.String format, System.ParamsArray args) [0x00023] in <7e05db41a20b45108859fa03b97088d4>:IL_0023 
  at System.String.Format (System.String format, System.Object[] args) [0x00020] in <7e05db41a20b45108859fa03b97088d4>:IL_0020 
  at SkillsPlusPlus.Logger.Warn (System.String message, System.Object[] formatArgs) [0x00011] in <032e00c0b23242269f2e2d911557bb46>:IL_0011 
  at SkillsPlusPlus.SkillModifierManager.LoadSkillModifiers () [0x001dd] in <032e00c0b23242269f2e2d911557bb46>:IL_01DD 
  ```
  
  The only thing I'm unsure of here is if `ChargeCorruptHandBeam` needs the `OnSkillLeveledUp` to avoid setting `surv` and `survlevel`.